### PR TITLE
schedule enter insert mode

### DIFF
--- a/lua/commit-prefix/init.lua
+++ b/lua/commit-prefix/init.lua
@@ -52,7 +52,9 @@ M.setup = function(config)
 
             if config.enter_insert_mode then
                 -- Enter insert mode at EOL
-                api.nvim_feedkeys('A', 'n', false)
+                vim.schedule(function ()
+                    api.nvim_feedkeys('A', 'n', false)
+                end)
             end
         end
     })


### PR DESCRIPTION
Fixes a sneaky race condition that would cause an extra newline to be appended in the commit message buffer.